### PR TITLE
feat: 상세페이지의 관련상품 목록에서 해당 상품을 제거

### DIFF
--- a/src/components/Product/UseProductList.jsx
+++ b/src/components/Product/UseProductList.jsx
@@ -22,7 +22,7 @@ export function UseProductList(props) {
     );
   }
 
-  const slicedProducts = productsState.slice(0, props.count);
+  const slicedProducts = productsState.filter(item => item.id !== props.id).slice(0, props.count);
 
   return (
     <div className="productContainer">

--- a/src/pages/ProductDetail/ProductDetailBody.jsx
+++ b/src/pages/ProductDetail/ProductDetailBody.jsx
@@ -23,7 +23,7 @@ export function ProductDetailBody(props) {
           <span>당근마켓 인기중고</span>
           <Link to="/PopularProduct">더 구경하기</Link>
         </div>
-        <UseProductList count={6} />
+        <UseProductList count={6} id={props.id} />
       </section>
     </StyledProductDetail>
   );
@@ -92,7 +92,7 @@ const StyledProductDetail = styled.div`
     font-style: normal;
     margin-top: 3px;
     font-size: 12px;
-    line-height: 3 px;
+    line-height: 3px;
     color: #868e96;
   }
   & .popularProduct {


### PR DESCRIPTION
이 경우는 쿼리를 해서 데이터를 2번 가지고 오기 보다는, 원래 데이터에서 해당 상세페이지 데이터만 제외하는게 효율이 높을것 같군요